### PR TITLE
Jcn 358 avoid saving empty settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ module.exports = {
 }
 ```
 
-Important:
+### Important!
 
-If the setting property `saveEmptyValue` is set to `false`, any of the following values `null - '' - 0 - {} - []` will not be saved.
+If the setting property `saveEmptyValue` is set to `false`, any of the following values `null - '' - 0 - {} - []` will not be saved. In any other case, the `saveEmptyValue` property is set to `true`.
 
 ### Settings fetch
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ module.exports = {
 		[settingName]: {
 			description: 'A description of what this setting does',
 			struct: 'The validation to use with @janiscommerce/superstruct package',
-			default: settingDefaultValue // Of any type
+			default: settingDefaultValue, // Of any type
+			saveEmptyValue: false
 		}
 	}
 }
@@ -44,18 +45,24 @@ module.exports = {
 		defaultStatus: {
 			description: 'The status to be set to a product if any status is provided',
 			struct: struct.enum(['active', 'inactive']),
-			default: 'active'
+			default: 'active',
+			saveEmptyValue: false
 		},
 	},
 	sku: {
 		defaultUnitMultiplier: {
 			description: 'The unit multiplier to be set to an SKU if any multiplier is provided',
 			struct: 'number & positive',
-			default: 1
+			default: 1,
+			saveEmptyValue: true
 		}
 	}
 }
 ```
+
+Important:
+
+If the setting property `saveEmptyValue` is set to `false`, any of the following values `null - '' - 0 - {} - []` will not be saved.
 
 ### Settings fetch
 

--- a/lib/client-settings.js
+++ b/lib/client-settings.js
@@ -53,7 +53,7 @@ module.exports = class ClientSettings {
 	}
 
 	/**
-	 * Get the value of an entity setting (client-defined or default vvalue)
+	 * Get the value of an entity setting (client-defined or default value)
 	 *
 	 * @param {string} entity The entity to search for
 	 * @param {string} settingName The name of the setting to get

--- a/lib/put-setting-api.js
+++ b/lib/put-setting-api.js
@@ -1,13 +1,17 @@
 'use strict';
 
 const assert = require('assert');
+const path = require('path');
+
 const { API } = require('@janiscommerce/api');
 const { struct } = require('@janiscommerce/superstruct');
-const path = require('path');
 
 const DefinitionFetcher = require('./definition-fetcher');
 
 const clientModelPath = path.join(process.cwd(), process.env.MS_PATH || '', 'models', 'client');
+
+const isObject = param => !!(param && typeof param === 'object' && !Array.isArray(param));
+
 module.exports = class PutSettingApi extends API {
 
 	get model() {
@@ -26,23 +30,21 @@ module.exports = class PutSettingApi extends API {
 
 		const definition = await DefinitionFetcher.load(this.settingsPath);
 
-		const [entity] = this.pathParameters;
+		this.entity = this.pathParameters[0];
 
-		if(!definition[entity])
-			throw new Error(`Entity ${entity} has no settings defined`);
+		if(!definition[this.entity])
+			throw new Error(`Entity ${this.entity} has no settings defined`);
 
-		this.defaultSettings = definition[entity];
+		this.defaultSettings = definition[this.entity];
 
 		this.validateSettingStruct();
 	}
 
 	async process() {
 
-		const [entity] = this.pathParameters;
-
 		const dataToSave = this.formatDataToSave();
 
-		return this.model.update({ [`settings.${entity}`]: dataToSave }, { code: this.session.clientCode });
+		return this.updateClientSettings(dataToSave);
 	}
 
 	validateSettingStruct() {
@@ -58,25 +60,56 @@ module.exports = class PutSettingApi extends API {
 
 		}, {});
 	}
-
+	
 	formatDataToSave() {
 
 		return Object.entries(this.data).reduce((dataFormatted, [settingName, settingValue]) => {
 
-			if(!this.equalValues(settingValue, this.defaultSettings[settingName].default))
+			if(this.shouldSaveSetting(settingName, settingValue))
 				dataFormatted[settingName] = settingValue;
 
 			return dataFormatted;
 		}, {});
 	}
 
+	shouldSaveSetting(settingName, settingValue) {
+
+		if(this.equalValues(settingValue, this.defaultSettings[settingName].default))
+			return false;
+
+		if(this.isEmptySetting(settingValue) && this.defaultSettings[settingName].saveEmptyValue === false)
+			return false;
+
+		return true;
+	}
+
 	equalValues(value, test) {
+
 		try {
 			assert.deepStrictEqual(value, test);
 			return true;
 		} catch(e) {
 			return false;
 		}
+	}
+
+	isEmptySetting(settingValue) {
+
+		return !!(
+			settingValue === null ||
+			(typeof settingValue === 'string' && !settingValue) ||
+			(typeof settingValue === 'number' && Number.isNaN(Number(settingValue)) || settingValue === 0) ||
+			(Array.isArray(settingValue) && !settingValue.length) ||
+			(isObject(settingValue) && !Object.keys(settingValue).length && !(settingValue instanceof Date))
+		);
+	}
+
+	updateClientSettings(dataToSave) {
+
+		if(!Object.keys(dataToSave).length)
+			return;
+
+		return this.model.update({ [`settings.${this.entity}`]: dataToSave }, { code: this.session.clientCode });
 	}
 
 };

--- a/lib/put-setting-api.js
+++ b/lib/put-setting-api.js
@@ -105,10 +105,6 @@ module.exports = class PutSettingApi extends API {
 	}
 
 	updateClientSettings(dataToSave) {
-
-		if(!Object.keys(dataToSave).length)
-			return;
-
 		return this.model.update({ [`settings.${this.entity}`]: dataToSave }, { code: this.session.clientCode });
 	}
 

--- a/lib/put-setting-api.js
+++ b/lib/put-setting-api.js
@@ -98,7 +98,7 @@ module.exports = class PutSettingApi extends API {
 		return !!(
 			(settingValue === null) ||
 			(typeof settingValue === 'string' && !settingValue) ||
-			(typeof settingValue === 'number' && Number.isNaN(Number(settingValue)) || settingValue === 0) ||
+			(typeof settingValue === 'number' && (Number.isNaN(Number(settingValue)) || settingValue === 0)) ||
 			(Array.isArray(settingValue) && !settingValue.length) ||
 			(isObject(settingValue) && !Object.keys(settingValue).length && !(settingValue instanceof Date))
 		);

--- a/lib/put-setting-api.js
+++ b/lib/put-setting-api.js
@@ -97,10 +97,10 @@ module.exports = class PutSettingApi extends API {
 
 		return !!(
 			(settingValue === null) ||
-			((typeof settingValue === 'string' && !settingValue) ||
+			(typeof settingValue === 'string' && !settingValue) ||
 			(typeof settingValue === 'number' && Number.isNaN(Number(settingValue)) || settingValue === 0) ||
 			(Array.isArray(settingValue) && !settingValue.length) ||
-			(isObject(settingValue) && !Object.keys(settingValue).length && !(settingValue instanceof Date)))
+			(isObject(settingValue) && !Object.keys(settingValue).length && !(settingValue instanceof Date))
 		);
 	}
 

--- a/lib/put-setting-api.js
+++ b/lib/put-setting-api.js
@@ -30,7 +30,7 @@ module.exports = class PutSettingApi extends API {
 
 		const definition = await DefinitionFetcher.load(this.settingsPath);
 
-		this.entity = this.pathParameters[0];
+		[this.entity] = this.pathParameters;
 
 		if(!definition[this.entity])
 			throw new Error(`Entity ${this.entity} has no settings defined`);

--- a/lib/put-setting-api.js
+++ b/lib/put-setting-api.js
@@ -60,7 +60,7 @@ module.exports = class PutSettingApi extends API {
 
 		}, {});
 	}
-	
+
 	formatDataToSave() {
 
 		return Object.entries(this.data).reduce((dataFormatted, [settingName, settingValue]) => {
@@ -96,11 +96,11 @@ module.exports = class PutSettingApi extends API {
 	isEmptySetting(settingValue) {
 
 		return !!(
-			settingValue === null ||
-			(typeof settingValue === 'string' && !settingValue) ||
+			(settingValue === null) ||
+			((typeof settingValue === 'string' && !settingValue) ||
 			(typeof settingValue === 'number' && Number.isNaN(Number(settingValue)) || settingValue === 0) ||
 			(Array.isArray(settingValue) && !settingValue.length) ||
-			(isObject(settingValue) && !Object.keys(settingValue).length && !(settingValue instanceof Date))
+			(isObject(settingValue) && !Object.keys(settingValue).length && !(settingValue instanceof Date)))
 		);
 	}
 

--- a/tests/put-setting-api.js
+++ b/tests/put-setting-api.js
@@ -255,7 +255,7 @@ describe('Setting Api Put Tests', () => {
 			after: (response, sinon) => {
 				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
 					'settings.sample-entity': {}
-			}, { code: 'defaultClient' });
+				}, { code: 'defaultClient' });
 			}
 		},
 		{

--- a/tests/put-setting-api.js
+++ b/tests/put-setting-api.js
@@ -53,8 +53,8 @@ describe('Setting Api Put Tests', () => {
 			'object-sample-setting': {
 				description: 'Some setting description',
 				struct: 'object?',
-				default: { 
-					exampleProperty: 'exampleValue' 
+				default: {
+					exampleProperty: 'exampleValue'
 				},
 				saveEmptyValue: false
 			},
@@ -174,7 +174,7 @@ describe('Setting Api Put Tests', () => {
 				sinon.stub(ClientModel.prototype, 'update').resolves(1);
 			},
 			request: {
-				data: { 
+				data: {
 					'sample-setting': '',
 					'other-sample-setting': 15
 				},

--- a/tests/put-setting-api.js
+++ b/tests/put-setting-api.js
@@ -237,7 +237,6 @@ describe('Setting Api Put Tests', () => {
 		{
 			description:
 				'Should not save the settings when each setting are empty, and by default it is not allowed to save empty settings',
-			getResponse: console.log,
 			before: sinon => {
 
 				mockRequire(defaultDefinitionPath, settingsDefinitionWithSaveEmptyValueAsFalse);

--- a/tests/put-setting-api.js
+++ b/tests/put-setting-api.js
@@ -20,18 +20,58 @@ describe('Setting Api Put Tests', () => {
 			'sample-setting': {
 				description: 'Some setting description',
 				struct: 'string?',
-				default: 'sample-default-value'
+				default: 'sample-default-value',
+				saveEmptyValue: false
 			},
 			'other-sample-setting': {
 				description: 'Some setting description',
 				struct: 'number?',
-				default: 0
+				default: 0,
+				saveEmptyValue: true
 			}
 		}
 	};
 
 	const settingsDefinitionRequestData = {
 		'sample-setting': 'new-setting-value'
+	};
+
+	const settingsDefinitionWithSaveEmptyValueAsFalse = {
+		'sample-entity': {
+			'string-sample-setting': {
+				description: 'Some setting description',
+				struct: 'string?',
+				default: 'sample-default-value',
+				saveEmptyValue: false
+			},
+			'number-sample-setting': {
+				description: 'Some setting description',
+				struct: 'number?',
+				default: 1,
+				saveEmptyValue: false
+			},
+			'object-sample-setting': {
+				description: 'Some setting description',
+				struct: 'object?',
+				default: { 
+					exampleProperty: 'exampleValue' 
+				},
+				saveEmptyValue: false
+			},
+			'array-sample-setting': {
+				description: 'Some setting description',
+				struct: 'array?',
+				default: ['exampleItem'],
+				saveEmptyValue: false
+			}
+		}
+	};
+
+	const emptySettingsDefinitionRequestData = {
+		'string-sample-setting': '',
+		'number-sample-setting': 0,
+		'object-sample-setting': {},
+		'array-sample-setting': []
 	};
 
 	const defaultDefinitionPath = DefinitionFetcher.getPath();
@@ -101,30 +141,6 @@ describe('Setting Api Put Tests', () => {
 			}
 		},
 		{
-			description: 'Should save an empty object if every value is the default value',
-			before: sinon => {
-
-				mockRequire(defaultDefinitionPath, settingsDefinition);
-				mockRequire(clientPath, ClientModel);
-
-				sinon.stub(ClientModel.prototype, 'update').resolves(1);
-			},
-			request: {
-				data: {
-					'sample-setting': settingsDefinition['sample-entity']['sample-setting'].default,
-					'other-sample-setting': settingsDefinition['sample-entity']['other-sample-setting'].default
-				},
-				pathParameters: ['sample-entity']
-			},
-			session: true,
-			response: { code: 200 },
-			after: (response, sinon) => {
-				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
-					'settings.sample-entity': {}
-				}, { code: 'defaultClient' });
-			}
-		},
-		{
 			description: 'Should save only the setting has change from default value',
 			before: sinon => {
 
@@ -145,6 +161,30 @@ describe('Setting Api Put Tests', () => {
 			after: (response, sinon) => {
 				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
 					'settings.sample-entity': { 'sample-setting': 'not-default' }
+				}, { code: 'defaultClient' });
+			}
+		},
+		{
+			description: 'Should save only an one setting, because the second is an empty setting',
+			before: sinon => {
+
+				mockRequire(defaultDefinitionPath, settingsDefinition);
+				mockRequire(clientPath, ClientModel);
+
+				sinon.stub(ClientModel.prototype, 'update').resolves(1);
+			},
+			request: {
+				data: { 
+					'sample-setting': '',
+					'other-sample-setting': 15
+				},
+				pathParameters: ['sample-entity']
+			},
+			session: true,
+			response: { code: 200 },
+			after: (response, sinon) => {
+				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
+					'settings.sample-entity': { 'other-sample-setting': 15 }
 				}, { code: 'defaultClient' });
 			}
 		},
@@ -170,6 +210,49 @@ describe('Setting Api Put Tests', () => {
 				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
 					'settings.sample-entity': { 'sample-setting': 'not-default' }
 				}, { code: 'defaultClient' });
+			}
+		},
+		{
+			description: 'Should not save the settings when each setting value is the default value',
+			before: sinon => {
+
+				mockRequire(defaultDefinitionPath, settingsDefinition);
+				mockRequire(clientPath, ClientModel);
+
+				sinon.stub(ClientModel.prototype, 'update');
+			},
+			request: {
+				data: {
+					'sample-setting': settingsDefinition['sample-entity']['sample-setting'].default,
+					'other-sample-setting': settingsDefinition['sample-entity']['other-sample-setting'].default
+				},
+				pathParameters: ['sample-entity']
+			},
+			session: true,
+			response: { code: 200 },
+			after: (response, sinon) => {
+				sinon.assert.notCalled(ClientModel.prototype.update);
+			}
+		},
+		{
+			description:
+				'Should not save the settings when each setting are empty, and by default it is not allowed to save empty settings',
+			getResponse: console.log,
+			before: sinon => {
+
+				mockRequire(defaultDefinitionPath, settingsDefinitionWithSaveEmptyValueAsFalse);
+				mockRequire(clientPath, ClientModel);
+
+				sinon.stub(ClientModel.prototype, 'update');
+			},
+			request: {
+				data: emptySettingsDefinitionRequestData,
+				pathParameters: ['sample-entity']
+			},
+			session: true,
+			response: { code: 200 },
+			after: (response, sinon) => {
+				sinon.assert.notCalled(ClientModel.prototype.update);
 			}
 		},
 		{

--- a/tests/put-setting-api.js
+++ b/tests/put-setting-api.js
@@ -213,7 +213,7 @@ describe('Setting Api Put Tests', () => {
 			}
 		},
 		{
-			description: 'Should not save the settings when each setting value is the default value',
+			description: 'Should save an empty object when each setting value is the default value',
 			before: sinon => {
 
 				mockRequire(defaultDefinitionPath, settingsDefinition);
@@ -231,12 +231,14 @@ describe('Setting Api Put Tests', () => {
 			session: true,
 			response: { code: 200 },
 			after: (response, sinon) => {
-				sinon.assert.notCalled(ClientModel.prototype.update);
+				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
+						'settings.sample-entity': {}
+				}, { code: 'defaultClient' });
 			}
 		},
 		{
 			description:
-				'Should not save the settings when each setting are empty, and by default it is not allowed to save empty settings',
+				'Should save an empty object when each setting are empty, and by default it is not allowed to save empty settings',
 			before: sinon => {
 
 				mockRequire(defaultDefinitionPath, settingsDefinitionWithSaveEmptyValueAsFalse);
@@ -251,7 +253,9 @@ describe('Setting Api Put Tests', () => {
 			session: true,
 			response: { code: 200 },
 			after: (response, sinon) => {
-				sinon.assert.notCalled(ClientModel.prototype.update);
+				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
+					'settings.sample-entity': {}
+			}, { code: 'defaultClient' });
 			}
 		},
 		{

--- a/tests/put-setting-api.js
+++ b/tests/put-setting-api.js
@@ -232,7 +232,7 @@ describe('Setting Api Put Tests', () => {
 			response: { code: 200 },
 			after: (response, sinon) => {
 				sinon.assert.calledOnceWithExactly(ClientModel.prototype.update, {
-						'settings.sample-entity': {}
+					'settings.sample-entity': {}
 				}, { code: 'defaultClient' });
 			}
 		},


### PR DESCRIPTION
Tarea: https://fizzmod.atlassian.net/browse/JCN-357
Subtarea: https://fizzmod.atlassian.net/browse/JCN-358

Dato a tener en cuenta:

En el archivo `lib/put-setting-api.js`, específicamente en la línea `80`
Valido el valor así
`this.defaultSettings[settingName].saveEmptyValue === false`
en vez de 
`!this.defaultSettings[settingName].saveEmptyValue`
 porque según mi análisis pueden haber schemas en los cuales no esté setteada esa propiedad.